### PR TITLE
🤖 Update `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 src/Exercism.Representers.CSharp/bin
 src/Exercism.Representers.CSharp/obj
 .appends
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,4 @@ src/Exercism.Representers.CSharp/obj
 .gitignore
 .gitattributes
 .dockerignore
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ src/Exercism.Representers.CSharp/bin
 src/Exercism.Representers.CSharp/obj
 .appends
 .git
+.github

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ src/Exercism.Representers.CSharp/obj
 .git
 .github
 .gitignore
+.gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@ src/Exercism.Representers.CSharp/obj
 .appends
 .git
 .github
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !src/Exercism.Representers.CSharp
 src/Exercism.Representers.CSharp/bin
 src/Exercism.Representers.CSharp/obj
+.appends

--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ src/Exercism.Representers.CSharp/obj
 .github
 .gitignore
 .gitattributes
+.dockerignore

--- a/src/Exercism.Representers.CSharp/Exercism.Representers.CSharp.csproj
+++ b/src/Exercism.Representers.CSharp/Exercism.Representers.CSharp.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
         <PackageReference Include="Serilog" Version="2.10.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
To help both speedup Docker builds _and_ prevent new containers being created when unrelated files changes, this PR adds some rules to the `.dockerignore` file (or add the file when it didn't exist).
See https://docs.docker.com/engine/reference/builder/#dockerignore-file for more information on `.dockerignore` files and what they do.

# Tracking issue

See https://github.com/exercism/exercism/issues/6113
